### PR TITLE
Show more information on assembly load failures. This will include

### DIFF
--- a/src/xunit.runner.kre/Program.cs
+++ b/src/xunit.runner.kre/Program.cs
@@ -340,7 +340,12 @@ namespace Xunit.ConsoleClient
             }
             catch (Exception ex)
             {
-                Console.WriteLine("{0}: {1}", ex.GetType().FullName, ex.Message);
+                lock (consoleLock)
+                {
+                    Console.ForegroundColor = ConsoleColor.Red;
+                    Console.WriteLine(ex);
+                    Console.ForegroundColor = ConsoleColor.Gray;
+                }
                 failed = true;
             }
 


### PR DESCRIPTION
Show more information on assembly load failures. This will include compilation error messages once again.

`ex.Message` is evil! :imp: 

/cc @bricelam 